### PR TITLE
Fix JS execution on WebKit

### DIFF
--- a/apply-ub-best-practices.sh
+++ b/apply-ub-best-practices.sh
@@ -175,7 +175,8 @@ class UBlueImageAPI:
         """Execute JavaScript in webview with error handling"""
         if self.webview:
             try:
-                self.webview.evaluate_javascript(script, -1, None, None, None, None, None)
+                # evaluate_javascript was removed from WebKitGTK; use run_javascript
+                self.webview.run_javascript(script, None, None, None)
             except Exception as e:
                 print(f"JavaScript execution error: {e}")
     

--- a/quick-setup-script.sh
+++ b/quick-setup-script.sh
@@ -34,7 +34,8 @@ class UBlueRebaseAPI:
     def execute_js(self, script):
         """Execute JavaScript in the webview"""
         if self.webview:
-            self.webview.evaluate_javascript(script, -1, None, None, None, None, None)
+            # evaluate_javascript is deprecated; use run_javascript for modern WebKit
+            self.webview.run_javascript(script, None, None, None)
     
     def get_system_status(self):
         """Get current system status using rpm-ostree"""

--- a/src/ublue-image-manager.py
+++ b/src/ublue-image-manager.py
@@ -40,7 +40,8 @@ class UBlueImageAPI:
         """Execute JavaScript in webview with error handling"""
         if self.webview:
             try:
-                self.webview.evaluate_javascript(script, -1, None, None, None, None, None)
+                # evaluate_javascript was removed from WebKitGTK 4.0; use run_javascript
+                self.webview.run_javascript(script, None, None, None)
             except Exception as e:
                 print(f"JavaScript execution error: {e}")
     


### PR DESCRIPTION
## Summary
- use `run_javascript` instead of deprecated `evaluate_javascript`

## Testing
- `./test.sh` *(fails: No module named 'gi')*

------
https://chatgpt.com/codex/tasks/task_e_68883e778cc48323914fdcfd15c2ae61